### PR TITLE
touched up readme and raw fracs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # mathe-to-tex
 A program to convert Mathematica source text to LaTeX
+
+note: requires an working installation of the Wolfram Engine and Wolframscript available for free at:
+
+### [Wolfram Engine](https://www.wolfram.com/engine/)
+### [Wolframscript](https://www.wolfram.com/wolframscript/)


### PR DESCRIPTION
this request removes the `re 'strict';` It is recommended to add once more if introducing new regexps to the process as it will catch any needless errors. Also added the ability to detect fractions that wrap the hyper functions, so if it's for example a QPh/QPh it will now render properly. 